### PR TITLE
feat: add version and run commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,5 +12,5 @@ mkdir -p "$BUILD_DIR"
 
 ### Build only the binary ###
 echo "==> Building binary..."
-go build -ldflags="-w -s -extldflags '-sectcreate __TEXT __info_plist Info.plist'" -o "$BUILD_DIR/stt-app" .
+go build -ldflags="-X main.version=dev -w -s -extldflags '-sectcreate __TEXT __info_plist Info.plist'" -o "$BUILD_DIR/stt-app" .
 echo "==> Build complete! Executable is at $BUILD_DIR/stt-app"

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"golang.design/x/hotkey/mainthread"
 )
 
+var version = "dev"
+
 const (
 	transcriptionRetries    = 3
 	transcriptionBinaryPath = "/opt/homebrew/bin/go-transcribe"
@@ -26,11 +28,26 @@ const (
 )
 
 func main() {
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "version":
+			fmt.Printf("overe version: %s\n", version)
+			return
+		case "run":
+			// continue to normal execution
+		default:
+			fmt.Printf("Unknown command: %s\n", os.Args[1])
+			fmt.Println("Available commands: run, version")
+			os.Exit(1)
+		}
+	}
+
 	// Set up logging to a file in the user's log directory.
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		log.Fatalf("Could not get user home directory: %v", err)
 	}
+
 	logDir := filepath.Join(homeDir, "Library", "Logs")
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		log.Fatalf("Could not create log directory: %v", err)


### PR DESCRIPTION
This commit introduces a 'version' command to display the build version of the application and a 'run' command to explicitly start the main application logic.

- The 'version' is dynamically injected during the build process. Local builds will show 'dev', while release builds will show the Git tag version.
- If no command is supplied, the application defaults to the 'run' behavior.
- The 'build.sh' script and '.goreleaser.yaml' have been updated to support version injection.