### PR TITLE
fix(ci): Remove amd64 build from release pipeline

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,6 @@ builds:
       - darwin
     goarch:
       - arm64
-      - amd64
     ldflags:
       - "-s -w -X main.version={{.Version}} -extldflags '-sectcreate __TEXT __info_plist Info.plist'"
 


### PR DESCRIPTION
Removes the `amd64` architecture from the GoReleaser configuration to resolve the cross-compilation build failure. The project will now only be built and released for the `arm64` architecture on macOS.