### PR TITLE
fix(ci): Correct Homebrew tap repository and dependency format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,11 +47,12 @@ brews:
     description: "A background app to record audio via a hotkey and transcribe it."
     license: "MIT"
     homepage: "https://github.com/kennyparsons/overe"
-    tap:
+    repository:
       owner: kennyparsons
-      name: homebrew-go-transcribe
+      name: homebrew-overe
+      token: "{{ .Env.GITHUB_TOKEN }}"
     dependencies:
-      - name: "go-transcribe"
+      - name: "kennyparsons/go-transcribe/go-transcribe"
     install: |
       bin.install "Overe"
     service: |


### PR DESCRIPTION
- Updates the GoReleaser configuration to push the Homebrew formula to the correct `homebrew-overe` repository, fixing the 403 permission error.
- Updates the deprecated `brews.tap` format to the new `repository` format.
- Fully qualifies the `go-transcribe` dependency to ensure it's sourced from the correct tap.