### PR TITLE
fix: Standardize binary name to lowercase 'overe'

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 version: 1
 
-project_name: Overe
+project_name: overe
 
 before:
   hooks:
@@ -9,7 +9,7 @@ before:
 
 builds:
   - main: .
-    binary: Overe
+    binary: overe
     env:
       - CGO_ENABLED=1
     goos:
@@ -38,7 +38,7 @@ changelog:
 
 brews:
   -
-    name: Overe
+    name: overe
     commit_author:
       name: Kenny Parsons
       email: kenny.parsons@gmail.com
@@ -54,9 +54,9 @@ brews:
     dependencies:
       - name: "kennyparsons/go-transcribe/go-transcribe"
     install: |
-      bin.install "Overe"
+      bin.install "overe"
     service: |
-      run [opt_bin/"Overe"]
+      run [opt_bin/"overe"]
       keep_alive true
       run_at_load true
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script builds the stt-app executable.
+# This script builds the overe executable.
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
@@ -12,5 +12,5 @@ mkdir -p "$BUILD_DIR"
 
 ### Build only the binary ###
 echo "==> Building binary..."
-go build -ldflags="-X main.version=dev -w -s -extldflags '-sectcreate __TEXT __info_plist Info.plist'" -o "$BUILD_DIR/stt-app" .
-echo "==> Build complete! Executable is at $BUILD_DIR/stt-app"
+go build -ldflags="-X main.version=dev -w -s -extldflags '-sectcreate __TEXT __info_plist Info.plist'" -o "$BUILD_DIR/overe" .
+echo "==> Build complete! Executable is at $BUILD_DIR/overe"

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	if err := os.MkdirAll(logDir, 0755); err != nil {
 		log.Fatalf("Could not create log directory: %v", err)
 	}
-	logFilePath := filepath.Join(logDir, "stt-app.log")
+	logFilePath := filepath.Join(logDir, "overe.log")
 	logFile, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		log.Fatalf("Could not open log file: %v", err)


### PR DESCRIPTION
- Updates `.goreleaser.yaml` to use 'overe' for the `project_name`, `binary`, and `brews.name`.
- Updates the `build.sh` script to produce a local 'overe' binary instead of 'stt-app'.
- Updates the log file path in `main.go` to `overe.log` for consistency.